### PR TITLE
Upgrade resize-observer-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "line-height": "0.3.1",
-    "resize-observer-polyfill": "1.4.2"
+    "resize-observer-polyfill": "^1.5.0"
   },
   "author": "Patrik Piskay",
   "license": "Apache-2.0"


### PR DESCRIPTION
I have a bug caused by `resize-observer-polyfill` on IE11 (See https://github.com/que-etc/resize-observer-polyfill/issues/20) which has been fixed with 1.5.0