### PR TITLE
Unknown prop 'level' (React 15)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const cloneWithChildren = (node, children, isRootEl, level) => ({
             }
           : {}),
     },
-    level,
+    'data-level': level,
     children,
   },
 });

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,6 @@ const cloneWithChildren = (node, children, isRootEl, level) => ({
             }
           : {}),
     },
-    'data-level': level,
     children,
   },
 });


### PR DESCRIPTION
The `level` attribute used here causes unknown prop warnings in React 15. I didn't see this prop being used as anything other than a debugging convenience and would love to quiet the error by changing it to a data attribute.

`Unknown prop 'level' on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop`