### PR TITLE
Eliminate unnecessary resizing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,17 @@ export default class TruncateMarkup extends React.Component {
   origText = null;
   clientWidth = null;
 
+  dimensions = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  };
+
   componentDidMount() {
     if (!this.isValid) {
       return;
@@ -224,24 +235,39 @@ export default class TruncateMarkup extends React.Component {
     /* Wrapper element resize handing */
     let initialRender = true;
 
-    this.resizeObserver = new ResizeObserver(() => {
-      if (initialRender) {
-        // ResizeObserer cb is called on initial render too so we are skipping here
-        initialRender = false;
-      } else {
-        // wrapper element has been resized, recalculating with the original text
-        this.shouldTruncate = false;
-        this.latestThatFits = null;
+    this.resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const dimensions = entry.contentRect;
+        if (
+          (this.dimensions.width === dimensions.width &&
+            this.dimensions.height === dimensions.height) ||
+          (!dimensions.left &&
+            !dimensions.top &&
+            !dimensions.width &&
+            !dimensions.height)
+        ) {
+          // skipping truncateMarkup because there's no real change
+        } else {
+          this.dimensions = dimensions;
+          if (initialRender) {
+            // ResizeObserer cb is called on initial render too so we are skipping here
+            initialRender = false;
+          } else {
+            // wrapper element has been resized, recalculating with the original text
+            this.shouldTruncate = false;
+            this.latestThatFits = null;
 
-        this.setState(
-          {
-            text: this.origText,
-          },
-          () => {
-            this.shouldTruncate = true;
-            this.truncate();
-          },
-        );
+            this.setState(
+              {
+                text: this.origText,
+              },
+              function() {
+                this.shouldTruncate = true;
+                this.truncate();
+              },
+            );
+          }
+        }
       }
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ export default class TruncateMarkup extends React.Component {
     let initialRender = true;
 
     this.resizeObserver = new ResizeObserver(entries => {
-      for (const entry of entries) {
+      entries.forEach(entry => {
         const dimensions = entry.contentRect;
         if (
           (this.dimensions.width === dimensions.width &&
@@ -268,7 +268,7 @@ export default class TruncateMarkup extends React.Component {
             );
           }
         }
-      }
+      });
     });
 
     this.resizeObserver.observe(this.el);


### PR DESCRIPTION
Hey, 

Firstly, love this library! We're finding it incredibly useful @ense-org. 

That said, we've seen a lot of slowing down since the way it's implemented resizes if the divs are being hidden and shown, etc., even if the size of the container doesn't actually change. This code allows it to resize when the container has actually changed to something requiring recalculation. 

The demo page works as expected, but let me know if you need modifications to be able to merge this (or any unintended consequences it may cause).