### PR TITLE
update prop types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "release": "release-it"
   },
   "peerDependencies": {
-    "prop-types": ">=15",
     "react": ">=15"
   },
   "devDependencies": {
@@ -64,7 +63,6 @@
     "polyserve": "^0.27.12",
     "prettier": "1.7.4",
     "prismjs": "1.8.1",
-    "prop-types": "15.6.0",
     "puppeteer": "^1.5.0",
     "puppeteer-screenshot-tester": "^1.0.4",
     "react": "^16.0.0",
@@ -74,6 +72,7 @@
   },
   "dependencies": {
     "line-height": "0.3.1",
+    "prop-types": "^15.6.0",
     "resize-observer-polyfill": "1.5.0"
   },
   "author": "Patrik Piskay",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8619,14 +8619,6 @@ prompts@^0.1.9:
     clorox "^1.0.3"
     sisteransi "^0.1.1"
 
-prop-types@15.6.0:
-  version "15.6.0"
-  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 prop-types@15.x, prop-types@^15.5.10, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"


### PR DESCRIPTION
Move it to `dependencies` instead of `peer` as officially suggested https://github.com/facebook/prop-types#how-to-depend-on-this-package

Since split from `react`, `prop-types` is now like a standalone library and should be treat as react-truncate-markup's dependency.

```
Using lockfile /home/circleci/project/doc/js/yarn.lock
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > react-truncate-markup@3.0.0" has unmet peer dependency "prop-types@>=15".
[4/4] Building fresh packages...
success Saved lockfile.
```

Peer dependencies should be used for [host package](https://nodejs.org/es/blog/npm/peer-dependencies/) (react)