### PR TITLE
Reuse resize observer

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -46,8 +46,88 @@ const rolesLeftEllipsis = node => {
   return `... (+${originalRolesCount - displayedRolesCount} roles)`;
 };
 
+class OnTruncateCallback extends Component {
+  state = { onTruncateCalledCount: 0 };
+
+  incrementTruncateCalledCount = wasTruncated => {
+    this.setState(state => ({
+      onTruncateCalledCount: state.onTruncateCalledCount + 1,
+      lastWasTruncated: wasTruncated,
+    }));
+  };
+  render() {
+    return (
+      <React.Fragment>
+        <ResizableBox
+          width={240}
+          height={40}
+          minConstraints={[150, 40]}
+          maxConstraints={[350, 40]}
+          className="box"
+        >
+          <TruncateMarkup
+            lines={1}
+            onTruncate={this.incrementTruncateCalledCount}
+          >
+            <div>
+              <strong>User roles: </strong>
+              {userRoles.join(', ')}
+            </div>
+          </TruncateMarkup>
+        </ResizableBox>
+        <div>
+          onTruncate called:{' '}
+          <b>
+            {this.state.onTruncateCalledCount}x<b />
+          </b>
+        </div>
+        {this.state.lastWasTruncated !== undefined && (
+          <div>
+            Did truncate? <b>{this.state.lastWasTruncated ? 'Yes' : 'No'}</b>
+          </div>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+const OnTruncateCallbackCodeHighlight = (
+  <pre>
+    <code
+      className="language-jsx"
+      dangerouslySetInnerHTML={{
+        __html: Prism.highlight(
+          `const userRoles = ['Admin', 'Editor', 'Collaborator', 'User'];
+
+<TruncateMarkup
+  lines={1}
+  onTruncate={wasTruncated => {
+    this.setState(state => ({
+      onTruncateCalledCount:
+        state.onTruncateCalledCount + 1,
+      lastWasTruncated: wasTruncated,
+    }));
+  }}
+>
+  <div>
+    <strong>User roles: </strong>
+    {userRoles.join(', ')}
+  </div>
+</TruncateMarkup>
+
+<div>
+  onTruncate called: {this.state.onTruncateCalledCount}x
+  Did truncate? {this.state.lastWasTruncated ? 'Yes' : 'No'}
+</div>
+`,
+          Prism.languages.javascript,
+        ),
+      }}
+    />
+  </pre>
+);
 class Demo extends Component {
-  state = { shouldTruncate: true, onTruncateCalledCount: 0 };
+  state = { shouldTruncate: true };
 
   toggleTruncate = () => {
     this.setState(state => ({ shouldTruncate: !state.shouldTruncate }));
@@ -491,77 +571,10 @@ const wordCountEllipsis = node => {
 
           <div className="block">
             <div className="eval">
-              <ResizableBox
-                width={240}
-                height={40}
-                minConstraints={[150, 40]}
-                maxConstraints={[350, 40]}
-                className="box"
-              >
-                <TruncateMarkup
-                  lines={1}
-                  onTruncate={wasTruncated => {
-                    this.setState(state => ({
-                      onTruncateCalledCount: state.onTruncateCalledCount + 1,
-                      lastWasTruncated: wasTruncated,
-                    }));
-                  }}
-                >
-                  <div>
-                    <strong>User roles: </strong>
-                    {userRoles.join(', ')}
-                  </div>
-                </TruncateMarkup>
-              </ResizableBox>
-              <div>
-                onTruncate called:{' '}
-                <b>
-                  {this.state.onTruncateCalledCount}x<b />
-                </b>
-              </div>
-              {this.state.lastWasTruncated !== undefined && (
-                <div>
-                  Did truncate?{' '}
-                  <b>{this.state.lastWasTruncated ? 'Yes' : 'No'}</b>
-                </div>
-              )}
+              <OnTruncateCallback />
             </div>
 
-            <div className="code">
-              <pre>
-                <code
-                  className="language-jsx"
-                  dangerouslySetInnerHTML={{
-                    __html: Prism.highlight(
-                      `const userRoles = ['Admin', 'Editor', 'Collaborator', 'User'];
-
-<TruncateMarkup
-  lines={1}
-  onTruncate={wasTruncated => {
-    this.setState(state => ({
-      onTruncateCalledCount:
-        state.onTruncateCalledCount + 1,
-      lastWasTruncated: wasTruncated,
-    }));
-  }}
->
-  <div>
-    <strong>User roles: </strong>
-    {userRoles.join(', ')}
-  </div>
-</TruncateMarkup>
-
-<div>
-  onTruncate called: {this.state.onTruncateCalledCount}x
-  Did truncate? {this.state.lastWasTruncated ? 'Yes' : 'No'}
-</div>
-`,
-                      Prism.languages.javascript,
-                    ),
-                  }}
-                />
-              </pre>
-            </div>
+            <div className="code">{OnTruncateCallbackCodeHighlight}</div>
           </div>
 
           <h2 id="tokenize-words">Tokenize: words</h2>


### PR DESCRIPTION
Closes https://github.com/parsable/react-truncate-markup/issues/26

## Current behavior:
1. `<TruncateMarkup />` is rendered
2. resize observer is attached on the DOM element, first event is ignored for such element, because it just rendered
3. whenever the DOM tree is updated, `<TruncateMarkup />` is re-rendered by React , a new resize observer is attached although it could be the very same DOM element. Again, first event is ignored, but this time the element has already been rendered before
4. This accidentally improved the performance, because some events got skipped - instead of proper event throttling. Additionally, it caused the issue https://github.com/parsable/react-truncate-markup/issues/26

## Bahaviour with this PR
1. `<TruncateMarkup />` is rendered
2. resize observer is attached on the DOM element, first event is ignored for such element, because it just rendered
3. whenever the DOM tree is updated, `<TruncateMarkup />` is re-rendered by React, the observer stays the same if the DOM elements stays the same. If a new DOM element is created, React cleans after itself and it first sets the `ref` for element to `null` which, in effect, cleans up the resize observer. For the new DOM element, new resize observer is created and again, first event is ignored because it just rendered
4. The way the demo page is written, it had some performance issues. The example mentioned in https://github.com/parsable/react-truncate-markup/issues/26   re-renderes the whole demo page with each resize event (well, with optimized React state updates batches). As a result, I also extracted that example to a separate component


FYI, I have approximate plan how to remove the `UNSAFE_componentWillReceiveProps` and this PR is also a little step towards that goal.