### PR TITLE
Allow resize-observer-polyfill 1.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-truncate-markup",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "React component for truncating JSX markup",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",
@@ -82,7 +82,7 @@
     "line-height": "0.3.1",
     "memoize-one": "^5.1.1",
     "prop-types": "^15.6.0",
-    "resize-observer-polyfill": "1.5.0"
+    "resize-observer-polyfill": "1.5.x"
   },
   "author": "Patrik Piskay",
   "license": "Apache-2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9635,10 +9635,10 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-resize-observer-polyfill@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
-  integrity sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg==
+resize-observer-polyfill@1.5.x:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Version 1.5.1 exports a TypeScript interface.
https://github.com/que-etc/resize-observer-polyfill/releases/tag/1.5.1